### PR TITLE
feature/php8.1-deprecations: add return types as PHP8.1 expects it

### DIFF
--- a/src/SoapClient.php
+++ b/src/SoapClient.php
@@ -160,7 +160,7 @@ class SoapClient extends BaseSoapClient
     /**
      * {@inheritDoc}
      */
-    public function __call($method, $args)
+    public function __call($method, $args) : mixed
     {
         $event = new CallEvent($method, $args);
         $this->eventDispatcher->dispatch($event, Events::CALL);
@@ -177,7 +177,7 @@ class SoapClient extends BaseSoapClient
     /**
      * {@inheritDoc}
      */
-    public function __soapCall($method, $args, $options = [], $inputHeaders = [], &$outputHeaders = [])
+    public function __soapCall($method, $args, $options = [], $inputHeaders = [], &$outputHeaders = []) : mixed
     {
         $event = new CallEvent($method, $args);
         $this->eventDispatcher->dispatch($event, Events::CALL);
@@ -200,7 +200,7 @@ class SoapClient extends BaseSoapClient
     /**
      * {@inheritDoc}
      */
-    public function __doRequest($request, $location, $action, $version, $oneWay = 0)
+    public function __doRequest($request, $location, $action, $version, $oneWay = 0) : ?string
     {
         $dom = new \DOMDocument();
         $dom->loadXML($request);


### PR DESCRIPTION
Changes to PHP 8.1 generated deprecation notices when using this Client. Therefor I have added the return types as PHP 8.1 expects it.

To do:
- [ ]  Confirm compatibility with minimum PHP version (PHP 7.1)